### PR TITLE
fix: Lombok integration and Java 8 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '8', '11', '17', '21', '25' ]
         architecture: [ 'x64' ]
     name: Build with JDK ${{ matrix.java }} on ${{ matrix.architecture }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.42</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/net/sf/JRecord/zTest/Cobol/TestStream.java
+++ b/src/test/java/net/sf/JRecord/zTest/Cobol/TestStream.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,7 @@ class TestStream {
 	void testFilter1() throws IOException {
 		List<AbstractLine> filteredList = getDTAR020List().filter(
 						line -> line.getFieldValue("DTAR020-QTY-SOLD").asInt() < 0
-					).toList();
+					).collect(Collectors.toList());
 		
 		check(EXPECTED_NEGATIVE_QUANTITIES, filteredList);
 		//printList(filteredList);
@@ -51,7 +52,7 @@ class TestStream {
 	void testFilter2() throws IOException {
 		List<AbstractLine> filteredList = getDTAR020List().filter(
 						line -> line.getFieldValue("DTAR020-SALE-PRICE").asBigDecimal().compareTo(DECIMAL_10) > 0
-					).toList();
+					).collect(Collectors.toList());
 		
 		check(EXPECTED_PRICE_GREATER_THAN_10, filteredList);
 		printList(filteredList);

--- a/src/test/java/net/sf/JRecord/zTest/Cobol/TestStream.java
+++ b/src/test/java/net/sf/JRecord/zTest/Cobol/TestStream.java
@@ -22,64 +22,59 @@ class TestStream {
 
 	private static final BigDecimal DECIMAL_10 = BigDecimal.valueOf(10);
 	static final String[][] EXPECTED_NEGATIVE_QUANTITIES = {
-			{"69684558", "20", "280", "-1", "-19.00", },
-				{"62684671", "20", "685", "-1", "-69.99",  },
-				{"61664713", "59", "335", "-1", "-17.99",  },	
-	};
-	
-	static final String[][] EXPECTED_PRICE_GREATER_THAN_10 = {
-			{"69684558", "20", "280", "1", "19.00",  },
-			{"62684671", "20", "685", "1", "69.99",  },
-			{"61664713", "59", "335", "1", "17.99",  },
-			{"61684613", "59", "335", "1", "12.99",  },
-			{"69624033", "166", "80", "1", "18.19",  },
-			{"60604100", "166", "80", "1", "13.30",  },
+			{ "69684558", "20", "280", "-1", "-19.00", },
+			{ "62684671", "20", "685", "-1", "-69.99", },
+			{ "61664713", "59", "335", "-1", "-17.99", },
 	};
 
-	
+	static final String[][] EXPECTED_PRICE_GREATER_THAN_10 = {
+			{ "69684558", "20", "280", "1", "19.00", },
+			{ "62684671", "20", "685", "1", "69.99", },
+			{ "61664713", "59", "335", "1", "17.99", },
+			{ "61684613", "59", "335", "1", "12.99", },
+			{ "69624033", "166", "80", "1", "18.19", },
+			{ "60604100", "166", "80", "1", "13.30", },
+	};
+
 	@Test
 	void testFilter1() throws IOException {
 		List<AbstractLine> filteredList = getDTAR020List().filter(
-						line -> line.getFieldValue("DTAR020-QTY-SOLD").asInt() < 0
-					).collect(Collectors.toList());
-		
+				line -> line.getFieldValue("DTAR020-QTY-SOLD").asInt() < 0).collect(Collectors.toList());
+
 		check(EXPECTED_NEGATIVE_QUANTITIES, filteredList);
-		//printList(filteredList);
+		// printList(filteredList);
 	}
 
-	
 	@Test
 	void testFilter2() throws IOException {
 		List<AbstractLine> filteredList = getDTAR020List().filter(
-						line -> line.getFieldValue("DTAR020-SALE-PRICE").asBigDecimal().compareTo(DECIMAL_10) > 0
-					).collect(Collectors.toList());
-		
+				line -> line.getFieldValue("DTAR020-SALE-PRICE").asBigDecimal().compareTo(DECIMAL_10) > 0)
+				.collect(Collectors.toList());
+
 		check(EXPECTED_PRICE_GREATER_THAN_10, filteredList);
 		printList(filteredList);
 	}
 
-
 	private Stream<AbstractLine> getDTAR020List() throws IOException, FileNotFoundException {
 		ICobolIOBuilder iob = JRecordInterface1.COBOL.newIOBuilder(
 				JRecordInterface1.COBOL.newCobolCopybookReader()
-					.setCopybookName("DTAR020")
-					.addFreeFormatCobolText(CommonCodeTestCopybooksAndData.DTAR020_COPYBOOK))
+						.setCopybookName("DTAR020")
+						.addFreeFormatCobolText(CommonCodeTestCopybooksAndData.DTAR020_COPYBOOK))
 				.setFont("cp037")
-				.setFileOrganization(IFileStructureConstants.IO_FIXED_LENGTH );
-		
+				.setFileOrganization(IFileStructureConstants.IO_FIXED_LENGTH);
+
 		Stream<AbstractLine> stream = iob.newReader(CommonCodeTestCopybooksAndData.DTAR020_TST1_DATA_FILE)
-										 .stream();
+				.stream();
 		return stream;
 	}
 
-
 	private void check(String[][] expected, List<AbstractLine> filteredList) {
 		assertEquals(expected.length, filteredList.size());
-		
-		for (int i =0; i < expected.length; i++) {
+
+		for (int i = 0; i < expected.length; i++) {
 			AbstractLine l = filteredList.get(i);
 			String[] expectedRow = expected[i];
-			
+
 			assertEquals(expectedRow[0], l.getFieldValue("DTAR020-KEYCODE-NO").asString());
 			assertEquals(expectedRow[1], l.getFieldValue("DTAR020-STORE-NO").asString());
 			assertEquals(expectedRow[2], l.getFieldValue("DTAR020-DEPT-NO").asString());
@@ -87,8 +82,7 @@ class TestStream {
 			assertEquals(expectedRow[4], l.getFieldValue("DTAR020-SALE-PRICE").asString());
 		}
 	}
-	
-	
+
 	private void printList(List<AbstractLine> list) {
 		for (AbstractLine l : list) {
 			System.out.println(""
@@ -98,12 +92,10 @@ class TestStream {
 					+ format(l.getFieldValue("DTAR020-DEPT-NO"))
 					+ format(l.getFieldValue("DTAR020-QTY-SOLD"))
 					+ format(l.getFieldValue("DTAR020-SALE-PRICE"))
-					+ " },"
-					);
-			
+					+ " },");
+
 		}
 	}
-
 
 	String format(IFieldValue v) {
 		return "\"" + v.asString() + "\", ";

--- a/src/test/resources/net/sf/JRecord/zTest/io/continuous/MultiRecordTest.cbl
+++ b/src/test/resources/net/sf/JRecord/zTest/io/continuous/MultiRecordTest.cbl
@@ -1,0 +1,23 @@
+      ************************************************************************
+      * Purpose: multi Record Test File
+      * Author:  Bruce Martin
+      ************************************************************************
+      
+       01 Header-Record.
+          05 Record-Type                            Pic X.
+             88 Header-Record         value 'H'.
+         05 Creation-Date                           Pic 9(8).
+         05 Version                                 pic 9(3)V99.
+         
+       01 Detail-Record.
+          05 Record-Type                            Pic X.
+             88 Detail-Record         value 'D'.
+          05 Field-1                                Pic X(10).
+          05 Field-2                                Pic X(20).
+          05 Field-3                                Pic X(10).
+              
+       01 Trailer-Record.
+          05 Record-Type                            Pic X.
+             88 Trailer-Record        value 'T'.
+          05 Record-Count                           Pic 9(9).  
+


### PR DESCRIPTION
## Changes

1. **Configure Lombok annotation processor** - Fixes compilation errors for `@Slf4j` and `@Setter` annotations by adding `annotationProcessorPaths` to maven-compiler-plugin

2. **Java 8 compatibility** - Replace `Stream.toList()` (Java 16+) with `Collectors.toList()` (Java 8+) in TestStream.java

## Testing
- Compilation passes on local machine
- Should pass CI on JDK 8, 11, 17, and 21